### PR TITLE
1.3.0.3

### DIFF
--- a/NowPlaying/NowPlaying.csproj
+++ b/NowPlaying/NowPlaying.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Dalamud.NET.Sdk/12.0.2">
   <PropertyGroup>
-    <Version>1.3.0.2</Version>
+    <Version>1.3.0.3</Version>
     <Description>Display what is playing in your server bar, and play/pause/skip.</Description>
     <PackageProjectUrl>https://github.com/wompscode/NowPlaying</PackageProjectUrl>
     <PackageLicenseExpression>AGPL-3.0-or-later</PackageLicenseExpression>

--- a/NowPlaying/Plugin.cs
+++ b/NowPlaying/Plugin.cs
@@ -137,8 +137,15 @@ public sealed class Plugin : IDalamudPlugin
         
         Sessions = Manager.GetSessions();
         
+        if (Sessions.Length <= 0)
+        {
+            // I don't know how I never thought about this. I've always got Spotify running, so I figure at no point did I go "hey, maybe I should check if there are any sessions at all.". Oh well.
+            Services.PluginLog.Info("No sessions found, not continuing..");
+            return;
+        } 
+        
         if (SessionIndex >= Sessions.Length) SessionIndex = 0;
-
+        
         Session = Sessions[SessionIndex];
         Services.PluginLog.Debug("Session is set.");
         

--- a/NowPlaying/ServerInfoDisplay.cs
+++ b/NowPlaying/ServerInfoDisplay.cs
@@ -32,6 +32,7 @@ public class ServerInfoDisplay
     {
         var song = Plugin.CurrentSong;
         var artist = Plugin.CurrentArtist;
+        var album = Plugin.CurrentAlbum;
 
         if (string.IsNullOrEmpty(song) && string.IsNullOrEmpty(artist))
         {
@@ -41,8 +42,9 @@ public class ServerInfoDisplay
 
         if (string.IsNullOrEmpty(song)) song = "n/a";
         if (string.IsNullOrEmpty(artist)) artist = "n/a";
+        if (string.IsNullOrEmpty(album)) album = "n/a";
 
-        Services.PluginLog.Debug($"HOP: {Plugin.HideOnPause}");
+        Services.PluginLog.Debug($"Hide on pause? {Plugin.HideOnPause}");
         
         if (Plugin.IsPaused && Plugin.HideOnPause)
         {
@@ -51,25 +53,18 @@ public class ServerInfoDisplay
             return;
         }
         
-        Services.PluginLog.Debug($"SISB: {Plugin.ShowInStatusBar}");
+        Services.PluginLog.Debug($"Should show in status bar? {Plugin.ShowInStatusBar}");
 
         entry.Shown = Plugin.ShowInStatusBar;
         var indicator = Plugin.IsPaused ? "||" : ">";
         
-        var displayNonTruncated = $"{artist} - {song}";
+        var tooltip = $"{song} by {artist}{(album == "n/a" ? "." : $" on {album}.")}";
+        
         if (artist.Length > 18) artist = artist.Substring(0, 18) + "..";
         if (song.Length > 24) song = song.Substring(0, 24) + "..";
-        var display = $"{artist} - {song}";
+        var display = $"♪ {indicator} {song} by {artist}";
 
-        if (display.Length >= 50)
-        {
-            entry.Text = indicator + " " + display.Substring(0, 50) + "...";
-            entry.Tooltip = displayNonTruncated;
-        }
-        else
-        {
-            entry.Text = indicator + " " + display;
-            entry.Tooltip = displayNonTruncated;
-        }
+        entry.Tooltip = tooltip;
+        entry.Text = display.Length >= 50 ? $"{display.Substring(0,50)}..." : $"{display}";
     }
 }


### PR DESCRIPTION
Fix for #7: Check if there are any audio sessions.
Implement album title in server bar tooltip.
Make server bar element a little prettier.
Upon plugin load, check if running in a WINE context. If so, don't initialise anything and if the user tries to run any NowPlaying associated commands, show a message saying that it only runs on Windows.