### PR TITLE
Linux support

### DIFF
--- a/NowPlaying/Configuration.cs
+++ b/NowPlaying/Configuration.cs
@@ -9,6 +9,7 @@ public class Configuration : IPluginConfiguration
     public int Version { get; set; } = 0;
     public bool ShowInStatusBar { get; set; } = true;
     public bool HideOnPause { get; set; } = false;
+    public bool MuteBgmOnPlay { get; set; } = false;
     public bool Truncate { get; set; } = true;
     public int MaxSongChars { get; set; } = 24;
     public int MaxArtistChars { get; set; } = 18;

--- a/NowPlaying/MediaControllers/DBus/WineDBusConnectionOptions.cs
+++ b/NowPlaying/MediaControllers/DBus/WineDBusConnectionOptions.cs
@@ -1,0 +1,37 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Tmds.DBus.Protocol;
+
+namespace NowPlaying.MediaControllers.DBus;
+
+internal class WineDBusConnectionOptions(string address) : DBusConnectionOptions
+{
+    protected override async ValueTask<SetupResult> SetupAsync(CancellationToken cancellationToken)
+    {
+        // There's gotta be a better way to obtain the UID of the currently running process.
+        // $UID env var does not work, calling out to /bin/id or /bin/sh will give no stdout, so you can't
+        // extract it from there.
+        var status = await File.ReadAllLinesAsync("/proc/self/status", cancellationToken);
+
+        foreach (var line in status)
+        {
+            if (!line.StartsWith("Uid:"))
+                continue;
+            
+            var splits = line.Split('\t');
+
+            return new SetupResult(address)
+            {
+                SupportsFdPassing = false,
+                UserId = splits[2], // effective UID
+                MachineId = Guid.Parse((await File.ReadAllTextAsync("/var/lib/dbus/machine-id", cancellationToken))
+                                       .AsSpan(0, 32))
+                                .ToString("N"),
+            };
+        }
+
+        throw new Exception("Could not determine the UID of the process from /proc/self/status");
+    }
+}

--- a/NowPlaying/MediaControllers/IMediaController.cs
+++ b/NowPlaying/MediaControllers/IMediaController.cs
@@ -1,0 +1,23 @@
+using System;
+using System.ComponentModel;
+
+namespace NowPlaying.MediaControllers;
+
+public interface IMediaController : IDisposable
+{
+    void Start();
+    
+    string CurrentSong { get; }
+    string CurrentArtist { get; }
+    string CurrentAlbum { get; }
+    bool IsPaused { get; }
+
+    event EventHandler OnUpdated;
+    
+    bool TryPrevious();
+    bool TryNext();
+    bool TryPlay();
+    bool TryPause();
+    bool TryPlayPauseToggle();
+    void CycleSession();
+}

--- a/NowPlaying/MediaControllers/MprisMediaController.cs
+++ b/NowPlaying/MediaControllers/MprisMediaController.cs
@@ -9,7 +9,7 @@ using Tmds.DBus.Protocol;
 
 namespace NowPlaying.MediaControllers;
 
-public class PlayerctlMediaController : IMediaController
+public class MprisMediaController : IMediaController
 {
     private readonly DBusConnection dbus;
     private IDisposable? dbusMatchRule;
@@ -21,7 +21,7 @@ public class PlayerctlMediaController : IMediaController
 
     private readonly SemaphoreSlim lockObject = new(1, 1);
     
-    public PlayerctlMediaController()
+    public MprisMediaController()
     {
         dbus = new DBusConnection(new WineDBusConnectionOptions(DBusAddress.Session!));
     }

--- a/NowPlaying/MediaControllers/MprisMediaController.cs
+++ b/NowPlaying/MediaControllers/MprisMediaController.cs
@@ -23,6 +23,7 @@ public class MprisMediaController : IMediaController
     
     public MprisMediaController()
     {
+        Services.PluginLog.Debug("Connecting to the D-Bus session bus: {SessionBusAddress}", DBusAddress.Session!);
         dbus = new DBusConnection(new WineDBusConnectionOptions(DBusAddress.Session!));
     }
 

--- a/NowPlaying/MediaControllers/NpsmMediaController.cs
+++ b/NowPlaying/MediaControllers/NpsmMediaController.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Threading;
+using NPSMLib;
+
+namespace NowPlaying.MediaControllers;
+
+public class NpsmMediaController : IMediaController
+{
+    private readonly NowPlayingSessionManager manager;
+    private NowPlayingSession? session;
+    private MediaPlaybackDataSource? src;
+    public NowPlayingSession[] Sessions = [];
+    public int SessionIndex;
+    
+    private bool isAttached;
+    private readonly Lock lockObject = new();
+    
+    public NpsmMediaController()
+    {
+        manager = new NowPlayingSessionManager();
+    }
+
+    public void Start()
+    {
+        manager.SessionListChanged += OnSessionListChanged;
+        OnSessionListChanged(null, null);
+    }
+    
+    public void Dispose()
+    {
+        manager.SessionListChanged -= OnSessionListChanged;
+
+        try
+        {
+            if (src != null && isAttached)
+                src.MediaPlaybackDataChanged -= PlaybackDataChanged;
+        }
+        catch  (Exception e)
+        {
+            // might not be the same source as it was before so if we try to unhook, it'll get upset but it largely can be ignored. i dont care. it works.
+            Services.PluginLog.Warning("Issue with unhooking Src.MediaPlaybackDataChanged, this error can likely be ignored as the playback source just likely was closed (error: {0}).", e.Message);
+        }
+        
+        GC.SuppressFinalize(this);
+    }
+
+    private void OnSessionListChanged(object? sender, NowPlayingSessionManagerEventArgs? args)
+    {
+        OnUpdated?.Invoke(this, EventArgs.Empty);
+
+        Sessions = manager.GetSessions();
+
+        if (Sessions.Length <= 0)
+            return;
+        
+        if (SessionIndex >= Sessions.Length)
+            SessionIndex = 0;
+
+        session = Sessions[SessionIndex];
+        Services.PluginLog.Debug("Session is set.");
+        
+        src = session.ActivateMediaPlaybackDataSource();
+        Services.PluginLog.Debug("Src is set.");
+        
+        if (src != null)
+        {
+            if (isAttached) return;
+            
+            src.MediaPlaybackDataChanged += PlaybackDataChanged;
+            PlaybackDataChanged(null, null);
+            isAttached = true;
+            
+            Services.PluginLog.Verbose("PlaybackDataChanged triggered.");
+        }
+        else
+        {
+            Services.PluginLog.Verbose("Src is null, no session was ever set.");
+        }
+    }
+    
+    private void PlaybackDataChanged(object? sender, MediaPlaybackDataChangedArgs? e)
+    {
+        if (session != null)
+        {
+            lock (lockObject)
+            {
+                if (src != null)
+                {
+                    var mediaDetails = src.GetMediaObjectInfo();
+                    var mediaPlaybackInfo = src.GetMediaPlaybackInfo();
+                    
+                    CurrentArtist = mediaDetails.Artist;
+                    CurrentSong = mediaDetails.Title;
+                    CurrentAlbum = mediaDetails.AlbumTitle;
+                    IsPaused = mediaPlaybackInfo.PlaybackState == MediaPlaybackState.Paused;
+                    OnUpdated?.Invoke(this, EventArgs.Empty);
+                }
+            }
+        }
+        else
+        {
+            Services.PluginLog.Verbose("Session is null, so assume player shut.");
+            CurrentArtist = "";
+            CurrentSong = "";
+            OnUpdated?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    public string CurrentSong { get; private set; } = string.Empty;
+    public string CurrentArtist { get; private set; } = string.Empty;
+    public string CurrentAlbum { get; private set; } = string.Empty;
+    public bool IsPaused { get; private set; }
+    
+    public event EventHandler? OnUpdated;
+
+    private bool TrySendMediaPlaybackCommand(MediaPlaybackCommands command)
+    {
+        if (src == null)
+            return false;
+
+        src.SendMediaPlaybackCommand(command);
+        return true;
+    }
+    
+    public bool TryPrevious()
+    {
+        return TrySendMediaPlaybackCommand(MediaPlaybackCommands.Previous);
+    }
+
+    public bool TryNext()
+    {
+        return TrySendMediaPlaybackCommand(MediaPlaybackCommands.Next);
+    }
+
+    public bool TryPlay()
+    {
+        return TrySendMediaPlaybackCommand(MediaPlaybackCommands.Play);
+    }
+
+    public bool TryPause()
+    {
+        return TrySendMediaPlaybackCommand(MediaPlaybackCommands.Pause);
+    }
+
+    public bool TryPlayPauseToggle()
+    {
+        return TrySendMediaPlaybackCommand(MediaPlaybackCommands.PlayPauseToggle);
+    }
+
+    public void CycleSession()
+    {
+        if (Sessions.Length == 0)
+            return;
+        
+        SessionIndex += 1;
+
+        if (SessionIndex >= Sessions.Length)
+            SessionIndex = 0;
+
+        if (src != null)
+        {
+            try
+            {
+                src.MediaPlaybackDataChanged -= PlaybackDataChanged;
+            }
+            catch  (Exception e)
+            {
+                // might not be the same source as it was before so if we try to unhook, it'll get upset but it largely can be ignored. i dont care. it works.
+                Services.PluginLog.Warning("Issue with unhooking Src.MediaPlaybackDataChanged, this error can likely be ignored as the playback source just likely was closed (error: {0}).", e.Message);
+            }
+            
+            isAttached = false;
+        }
+        
+        OnSessionListChanged(null, null);
+    }
+}

--- a/NowPlaying/MediaControllers/PlayerctlMediaController.cs
+++ b/NowPlaying/MediaControllers/PlayerctlMediaController.cs
@@ -91,19 +91,19 @@ public class PlayerctlMediaController : IMediaController
         GC.SuppressFinalize(this);
     }
 
-    private static (string, string, string) ReadNameOwnerChangedMessage(Message message, object? state)
+    private static (string, string, string)? ReadNameOwnerChangedMessage(Message message, object? state)
     {
         if (message.Signature.Length != 3
             || message.Signature[0] != 's'
             || message.Signature[1] != 's'
             || message.Signature[2] != 's')
-            throw new Exception("Unexpected signature for NameOwnerChanged, expected 'sss'");
+            return null;
                 
         var reader = message.GetBodyReader();
         var name = reader.ReadString();
 
         if (!name.StartsWith("org.mpris.MediaPlayer2."))
-            throw new Exception("don't care about non-mpris services");
+            return null;
                 
         var oldOwner = reader.ReadString();
         var newOwner = reader.ReadString();
@@ -111,12 +111,10 @@ public class PlayerctlMediaController : IMediaController
         return (name, oldOwner, newOwner);
     }
 
-    private async ValueTask HandleNameOwnerChangedSignal(Notification<(string, string, string)> notification)
+    private async ValueTask HandleNameOwnerChangedSignal(Notification<(string, string, string)?> notification)
     {
-        if (!notification.HasValue)
+        if (!notification.HasValue || notification.Value is not var (name, oldOwner, newOwner))
             return;
-
-        var (name, oldOwner, newOwner) = notification.Value;
 
         // ReSharper disable once MethodSupportsCancellation
         await lockObject.WaitAsync();

--- a/NowPlaying/MediaControllers/PlayerctlMediaController.cs
+++ b/NowPlaying/MediaControllers/PlayerctlMediaController.cs
@@ -1,0 +1,273 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Mpris.DBus;
+using NowPlaying.MediaControllers.DBus;
+using Tmds.DBus.Protocol;
+
+namespace NowPlaying.MediaControllers;
+
+public class PlayerctlMediaController : IMediaController
+{
+    private readonly DBusConnection dbus;
+    private IDisposable? dbusMatchRule;
+    private List<string> playerNames = [];
+    private int playerNameIndex;
+    private DBusService? mpris;
+    private Player? player;
+    private IDisposable? playerPropertyChangeObserver;
+
+    private readonly SemaphoreSlim lockObject = new(1, 1);
+    
+    public PlayerctlMediaController()
+    {
+        dbus = new DBusConnection(new WineDBusConnectionOptions(DBusAddress.Session!));
+    }
+
+    public void Start()
+    {
+        InitAsync().AsTask().Wait();
+    }
+
+    public async ValueTask InitAsync(CancellationToken token = default)
+    {
+        // Connect to the session bus
+        await dbus.ConnectAsync();
+        Services.PluginLog.Debug("Connected to the D-Bus session bus.");
+
+        // Add an event listener to listen for new players
+        var rule = new MatchRule
+        {
+            Type = MessageType.Signal,
+            Sender = "org.freedesktop.DBus",
+            Path = "/org/freedesktop/DBus",
+            Interface = "org.freedesktop.DBus",
+            Member = "NameOwnerChanged",
+            // Arg0Namespace doesn't work due to the library spelling it arg0Namespace and not arg0namespace
+        };
+
+        dbusMatchRule = await dbus.AddMatchAsync(
+                            rule,
+                            ReadNameOwnerChangedMessage,
+                            HandleNameOwnerChangedSignal,
+                            emitOnCapturedContext: false);
+        
+        // That covers adding/removing future services. However, we still need to fetch the list of services once.
+        var players = (await dbus.ListServicesAsync()).Where(s => s.StartsWith("org.mpris.MediaPlayer2."));
+
+        await lockObject.WaitAsync(token);
+        try
+        {
+            foreach (var name in players)
+            {
+                if (playerNames.Contains(name))
+                    continue;
+
+                Services.PluginLog.Debug("MediaPlayer2 service discovered: {Name}", name);
+                playerNames.Add(name);
+            }
+            
+            if (playerNames.Count <= 0)
+                return;
+
+            if (playerNameIndex >= playerNames.Count)
+                playerNameIndex = 0;
+
+            await UpdatePlayer();
+        } 
+        finally
+        {
+            lockObject.Release();
+        }
+    }
+    
+    public void Dispose()
+    {
+        playerPropertyChangeObserver?.Dispose();
+        dbusMatchRule?.Dispose();
+        dbus.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private static (string, string, string) ReadNameOwnerChangedMessage(Message message, object? state)
+    {
+        if (message.Signature.Length != 3
+            || message.Signature[0] != 's'
+            || message.Signature[1] != 's'
+            || message.Signature[2] != 's')
+            throw new Exception("Unexpected signature for NameOwnerChanged, expected 'sss'");
+                
+        var reader = message.GetBodyReader();
+        var name = reader.ReadString();
+
+        if (!name.StartsWith("org.mpris.MediaPlayer2."))
+            throw new Exception("don't care about non-mpris services");
+                
+        var oldOwner = reader.ReadString();
+        var newOwner = reader.ReadString();
+
+        return (name, oldOwner, newOwner);
+    }
+
+    private async ValueTask HandleNameOwnerChangedSignal(Notification<(string, string, string)> notification)
+    {
+        if (!notification.HasValue)
+            return;
+
+        var (name, oldOwner, newOwner) = notification.Value;
+
+        // ReSharper disable once MethodSupportsCancellation
+        await lockObject.WaitAsync();
+        try
+        {
+            if (oldOwner == string.Empty && newOwner != string.Empty && !playerNames.Contains(name))
+            {
+                Services.PluginLog.Debug("New MediaPlayer2 service added: {Name}", name);
+                playerNames.Add(name);
+            }
+            else if (oldOwner != string.Empty && newOwner == string.Empty)
+            {
+                Services.PluginLog.Debug("MediaPlayer2 service removed: {Name}", name);
+                playerNames.Remove(name);
+            }
+                    
+            if (playerNames.Count <= 0)
+                return;
+
+            if (playerNameIndex >= playerNames.Count)
+                playerNameIndex = 0;
+
+            await UpdatePlayer();
+        }
+        finally
+        {
+            lockObject.Release();
+        }
+    }
+
+    private async ValueTask UpdatePlayer()
+    {
+        var playerName = playerNames[playerNameIndex];
+        
+        Services.PluginLog.Debug("Selecting D-Bus MPRIS service {PlayerName}", playerName);
+
+        playerPropertyChangeObserver?.Dispose();
+        
+        mpris = new DBusService(dbus, playerName);
+        player = mpris.Value.CreatePlayer("/org/mpris/MediaPlayer2");
+        playerPropertyChangeObserver = await player.WatchPropertiesChangedAsync(OnPlayerPropertiesChanged);
+        
+        UpdateFromMetadata(await player.GetMetadataAsync());
+        IsPaused = await player.GetPlaybackStatusAsync() == "Paused";
+        OnUpdated?.Invoke(this, EventArgs.Empty);
+    }
+
+    private async ValueTask OnPlayerPropertiesChanged(IChangedPlayerProperties props)
+    {
+        if (props.HasPlaybackStatusChanged)
+            IsPaused = props.PlaybackStatus == "Paused";
+        
+        if (props.HasMetadataChanged && (props.Metadata != null || player != null))
+            UpdateFromMetadata(props.Metadata ?? await player!.GetMetadataAsync());
+        
+        OnUpdated?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void UpdateFromMetadata(Dictionary<string, VariantValue> metadata)
+    {
+        if (metadata.TryGetValue("xesam:title", out var title) && title.Type == VariantValueType.String)
+            CurrentSong = title.GetString();
+        else
+            CurrentSong = string.Empty;
+
+        if (metadata.TryGetValue("xesam:artist", out var artist) && artist.Type == VariantValueType.Array)
+            CurrentArtist = string.Join(", ", artist.GetArray<string>());
+        else
+            CurrentArtist = string.Empty;
+        
+        if (metadata.TryGetValue("xesam:album", out var album) && album.Type == VariantValueType.String)
+            CurrentAlbum = album.GetString();
+        else
+            CurrentAlbum = string.Empty;
+    }
+    
+    public string CurrentSong { get; private set; } = string.Empty;
+    public string CurrentArtist { get; private set; } = string.Empty;
+    public string CurrentAlbum { get; private set; } = string.Empty;
+    public bool IsPaused { get; private set; }
+    
+    public event EventHandler? OnUpdated;
+
+    public bool TryPrevious()
+    {
+        if (player is not { } p)
+            return false;
+
+        p.PreviousAsync().Wait();
+        return true;
+    }
+
+    public bool TryNext()
+    {
+        if (player is not { } p)
+            return false;
+
+        p.NextAsync().Wait();
+        return true;
+    }
+
+    public bool TryPlay()
+    {
+        if (player is not { } p)
+            return false;
+
+        p.PlayAsync().Wait();
+        return true;
+    }
+
+    public bool TryPause()
+    {
+        if (player is not { } p)
+            return false;
+
+        p.PauseAsync().Wait();
+        return true;
+    }
+
+    public bool TryPlayPauseToggle()
+    {
+        if (player is not { } p)
+            return false;
+
+        p.PlayPauseAsync().Wait();
+        return true;
+    }
+
+    public void CycleSession()
+    {
+        Task.Run(async () =>
+        {
+            await lockObject.WaitAsync();
+            try
+            {
+                if (playerNames.Count == 0)
+                    return;
+
+                playerNameIndex++;
+
+                if (playerNameIndex >= playerNames.Count)
+                    playerNameIndex = 0;
+                
+                await UpdatePlayer();
+            } 
+            finally
+            {
+                lockObject.Release();
+            }
+        }).Wait();
+    }
+    
+    
+}

--- a/NowPlaying/MediaControllers/PlayerctlMediaController.cs
+++ b/NowPlaying/MediaControllers/PlayerctlMediaController.cs
@@ -130,6 +130,11 @@ public class PlayerctlMediaController : IMediaController
                 Services.PluginLog.Debug("MediaPlayer2 service removed: {Name}", name);
                 playerNames.Remove(name);
             }
+            else
+            {
+                Services.PluginLog.Debug("MediaPlayer2 NameOwnerChanged: Name={Name} OldOwner={OldOwner} NewOwner={NewOwner}", name, oldOwner, newOwner);
+                return;
+            }
                     
             if (playerNames.Count <= 0)
                 return;

--- a/NowPlaying/NowPlaying.csproj
+++ b/NowPlaying/NowPlaying.csproj
@@ -10,5 +10,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NPSMLib" Version="0.9.14" />
+    <PackageReference Include="Tmds.DBus.Generator" Version="0.95.0" />
+    <PackageReference Include="Tmds.DBus.Protocol" Version="0.95.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <AdditionalFiles Include="dbus-xml/org.mpris.MediaPlayer2.Player.xml" Namespace="Mpris.DBus" DBusGeneratorMode="Proxy" />
   </ItemGroup>
 </Project>

--- a/NowPlaying/NowPlaying.json
+++ b/NowPlaying/NowPlaying.json
@@ -1,8 +1,8 @@
 {
   "Author": "wompscode",
   "Name": "NowPlaying",
-  "Punchline": "Display what is playing in your server bar, and play/pause/skip. (Windows only)",
-  "Description": "Display what is playing in your server bar, and play/pause/skip. Great with macros! (--> Windows only <--)",
+  "Punchline": "Display what is playing in your server bar, and play/pause/skip.",
+  "Description": "Display what is playing in your server bar, and play/pause/skip. Great with macros!",
   "ApplicableVersion": "any",
   "Tags": [
     "music",

--- a/NowPlaying/Plugin.cs
+++ b/NowPlaying/Plugin.cs
@@ -1,14 +1,14 @@
-﻿namespace NowPlaying;
-
-using System;
+﻿using System;
+using System.ComponentModel;
 using System.Runtime.InteropServices;
-
-using NPSMLib;
-
 using Dalamud.Game.Command;
+using Dalamud.Game.Config;
 using Dalamud.Plugin;
 using Dalamud.Utility;
 using Dalamud.Game.Gui.Dtr;
+using NowPlaying.MediaControllers;
+
+namespace NowPlaying;
 
 // ReSharper disable StringLiteralTypo
 // ReSharper disable IdentifierTypo
@@ -27,29 +27,23 @@ public sealed class Plugin : IDalamudPlugin
     // Config options
     public static bool ShowInStatusBar;
     public static bool HideOnPause;
+    public static bool MuteBgmOnPlay;
     public static bool Truncate;
     public static int  MaxSongChars;
     public static int  MaxArtistChars;
 
     // Song data
-    public static string CurrentSong = "";
-    public static string CurrentArtist = "";
-    public static string CurrentAlbum = "";
-    public static bool   IsPaused;
+    public static string CurrentSong => MediaController?.CurrentSong ?? string.Empty;
+    public static string CurrentArtist => MediaController?.CurrentArtist ?? string.Empty;
+    public static string CurrentAlbum => MediaController?.CurrentAlbum ?? string.Empty;
+    public static bool IsPaused => MediaController?.IsPaused ?? true;
     
     // IsWine result
     private static bool IsWine;
+    private static IMediaController? MediaController;
     
-    // Single-thread lock + check bool
-    private bool isAttached;
-    static readonly object LockObject = new ();
-
-    // SMTC
-    private static NowPlayingSessionManager? Manager;
-    private static NowPlayingSession? Session;
-    private static MediaPlaybackDataSource? Src;
-    public static NowPlayingSession[]? Sessions;
-    public static int SessionIndex;
+    // mute handling
+    private bool mutedGame;
 
     public Plugin(IDalamudPluginInterface pluginInterface)
     {
@@ -59,6 +53,7 @@ public sealed class Plugin : IDalamudPlugin
         Configuration = pluginInterface.GetPluginConfig() as Configuration ?? new Configuration();
         ShowInStatusBar = Configuration.ShowInStatusBar;
         HideOnPause = Configuration.HideOnPause;
+        MuteBgmOnPlay = Configuration.MuteBgmOnPlay;
         Truncate = Configuration.Truncate;
         MaxSongChars = Configuration.MaxSongChars;
         MaxArtistChars = Configuration.MaxArtistChars;
@@ -115,18 +110,41 @@ public sealed class Plugin : IDalamudPlugin
         {
             HelpMessage = "Cycle between active players."
         });
+        Services.CommandManager.AddHandler("/nowplaying mutebgmonplay", new CommandInfo(CommandHandler)
+        {
+            HelpMessage = "Whether to mute the game's BGM while music is playing.",
+        });
         Services.CommandManager.AddHandler("/npl", new CommandInfo(CommandHandler)
         {
             HelpMessage = "Alias for /nowplaying. Supports all the same arguments."
         });
         
         dtrDisplay = new ServerInfoDisplay(this);
-        if (!IsWine)
+
+        if (IsWine)
+            MediaController = new PlayerctlMediaController();
+        else
+            MediaController = new NpsmMediaController();
+
+        MediaController.OnUpdated += OnMediaControllerUpdated;
+        MediaController.Start();
+    }
+
+    private void OnMediaControllerUpdated(object? sender, EventArgs args)
+    {
+        if (!IsPaused && MuteBgmOnPlay && Services.GameConfig.TryGet(SystemConfigOption.IsSndBgm, out bool muted) && !muted)
         {
-            Manager = new NowPlayingSessionManager();
-            Manager.SessionListChanged += OnSessionListChanged;
-            OnSessionListChanged(null,null);
+            Services.GameConfig.Set(SystemConfigOption.IsSndBgm, true);
+            mutedGame = true;
         }
+
+        if (IsPaused && MuteBgmOnPlay && mutedGame)
+        {
+            Services.GameConfig.Set(SystemConfigOption.IsSndBgm, false);
+            mutedGame = false;
+        }
+        
+        dtrDisplay.Update();
     }
 
     public void CycleSessionDtr(DtrInteractionEvent interactionEvent)
@@ -134,97 +152,9 @@ public sealed class Plugin : IDalamudPlugin
         CycleSession();
     }
     
-    public void CycleSession()
+    public static void CycleSession()
     {
-        if (IsWine) return;
-
-        if (Sessions != null)
-        {
-            SessionIndex += 1;
-            if (SessionIndex >= Sessions.Length) SessionIndex = 0;
-        }
-
-        if (Src != null)
-        {
-            try
-            {
-                Src.MediaPlaybackDataChanged -= PlaybackDataChanged;
-            }
-            catch  (Exception e)
-            {
-                // might not be the same source as it was before so if we try to unhook, it'll get upset but it largely can be ignored. i dont care. it works.
-                Services.PluginLog.Warning("Issue with unhooking Src.MediaPlaybackDataChanged, this error can likely be ignored as the playback source just likely was closed (error: {0}).", e.Message);
-            }
-            isAttached = false;
-        }
-        OnSessionListChanged(null, null);
-    }
-    private void OnSessionListChanged(object? sender, NowPlayingSessionManagerEventArgs? e)
-    {
-        if (IsWine) return;
-
-        if (Manager == null) return;
-        dtrDisplay.Update();
-        
-        Sessions = Manager.GetSessions();
-        
-        // I don't know how I never thought about this. I've always got Spotify running, so I figure at no point did I go "hey, maybe I should check if there are any sessions at all.". Oh well.
-        if (Sessions.Length <= 0)
-            return;
-        
-        if (SessionIndex >= Sessions.Length) SessionIndex = 0;
-        
-        Session = Sessions[SessionIndex];
-        Services.PluginLog.Debug("Session is set.");
-        
-        Src = Session.ActivateMediaPlaybackDataSource();
-        Services.PluginLog.Debug("Src is set.");
-        
-        if (Src != null)
-        {
-            if (isAttached) return;
-            
-            Src.MediaPlaybackDataChanged += PlaybackDataChanged;
-            PlaybackDataChanged(null, null);
-            isAttached = true;
-            
-            Services.PluginLog.Verbose("PlaybackDataChanged triggered.");
-        }
-        else
-        {
-            Services.PluginLog.Verbose("Src is null, no session was ever set.");
-        }
-    }
-
-    private void PlaybackDataChanged(object? sender, MediaPlaybackDataChangedArgs? e)
-    {
-        if (IsWine) return;
-        
-        if (Session != null)
-        {
-            lock (LockObject)
-            {
-                if (Src != null)
-                {
-                    var mediaDetails = Src.GetMediaObjectInfo();
-                    var mediaPlaybackInfo = Src.GetMediaPlaybackInfo();
-                    
-                    CurrentArtist = mediaDetails.Artist;
-                    CurrentSong = mediaDetails.Title;
-                    CurrentAlbum = mediaDetails.AlbumTitle;
-                    IsPaused = mediaPlaybackInfo.PlaybackState == MediaPlaybackState.Paused;
-                    
-                    dtrDisplay.Update();
-                }
-            }
-        }
-        else
-        {
-            Services.PluginLog.Verbose("Session is null, so assume player shut.");
-            CurrentArtist = "";
-            CurrentSong = "";
-            dtrDisplay.Update();
-        }
+        MediaController?.CycleSession();
     }
 
     public void Dispose()
@@ -242,21 +172,13 @@ public sealed class Plugin : IDalamudPlugin
         Services.CommandManager.RemoveHandler("/nowplaying play");
         Services.CommandManager.RemoveHandler("/nowplaying pause");
         Services.CommandManager.RemoveHandler("/nowplaying cycle");
+        Services.CommandManager.RemoveHandler("/nowplaying mutebgmonplay");
         Services.CommandManager.RemoveHandler("/npl");
-
-        if (!IsWine)
-        {
-            if(Manager != null) Manager.SessionListChanged -= OnSessionListChanged;
-            try
-            {
-                if (Src != null && isAttached) Src.MediaPlaybackDataChanged -= PlaybackDataChanged;
-            }
-            catch  (Exception e)
-            {
-                // might not be the same source as it was before so if we try to unhook, it'll get upset but it largely can be ignored. i dont care. it works.
-                Services.PluginLog.Warning("Issue with unhooking Src.MediaPlaybackDataChanged, this error can likely be ignored as the playback source just likely was closed (error: {0}).", e.Message);
-            }
-        }
+        
+        if (MuteBgmOnPlay && mutedGame)
+            Services.GameConfig.Set(SystemConfigOption.IsSndBgm, false);
+        
+        MediaController?.Dispose();
         dtrDisplay.Dispose();
         Configuration.Save();
     }
@@ -267,12 +189,6 @@ public sealed class Plugin : IDalamudPlugin
         
         if (command == "/nowplaying" || command == "/npl")
         {
-            if (IsWine)
-            {
-                    Services.ChatGui.Print("NowPlaying only works under Windows. This plugin will do nothing as it has detected you are running from within a WINE environment. Sorry!");
-                return;
-            }
-
             if (argsSplit.Length < 1 || string.IsNullOrEmpty(args))
             {
                     Services.ChatGui.Print("[NowPlaying] valid subcommands: current, next, prev, play, pause, playpause, sb, hop, msc <int>, mac <int>, trunc.");
@@ -284,66 +200,24 @@ public sealed class Plugin : IDalamudPlugin
             switch (subcommand)
             {
                 case "next":
-                    if (Src != null)
-                    {
-                        Src.SendMediaPlaybackCommand(MediaPlaybackCommands.Next);
-                    }
-                    else
-                    {
-                        if (!IsPaused)
-                        {
-                            keybd_event(0xB0, 0, 1, IntPtr.Zero); // Next song key
-                        }
-                    }
+                    if ((MediaController == null || !MediaController.TryNext()) && !IsPaused)
+                        keybd_event(0xB0, 0, 1, IntPtr.Zero); // Next song key
                     break;
                 case "prev":
-                    if (Src != null)
-                    {
-                        Src.SendMediaPlaybackCommand(MediaPlaybackCommands.Previous);
-                    }
-                    else
-                    {
-                        if (!IsPaused)
-                        {
-                            keybd_event(0xB1 , 0, 1, IntPtr.Zero); // Previous song key
-                        }
-                    }
+                    if ((MediaController == null || !MediaController.TryPrevious()) && !IsPaused)
+                        keybd_event(0xB1 , 0, 1, IntPtr.Zero); // Previous song key
                     break;
                 case "play":
-                    if (Src != null)
-                    {
-                        Src.SendMediaPlaybackCommand(MediaPlaybackCommands.Play);
-                    }
-                    else
-                    {
-                        if (!IsPaused)
-                        {
-                            keybd_event(0xB3 , 0, 1, IntPtr.Zero); // Play pause key
-                        }
-                    }
+                    if ((MediaController == null || !MediaController.TryPlay()) && IsPaused)
+                        keybd_event(0xB3 , 0, 1, IntPtr.Zero); // Play pause key
                     break;
                 case "pause":
-                    if (Src != null)
-                    {
-                        Src.SendMediaPlaybackCommand(MediaPlaybackCommands.Pause);
-                    }
-                    else
-                    {
-                        if (!IsPaused)
-                        {
-                            keybd_event(0xB3 , 0, 1, IntPtr.Zero); // Play pause key
-                        }
-                    }
+                    if ((MediaController == null || !MediaController.TryPause()) && !IsPaused)
+                        keybd_event(0xB3 , 0, 1, IntPtr.Zero); // Play pause key
                     break;
                 case "playpause":
-                    if (Src != null)
-                    {
-                        Src.SendMediaPlaybackCommand(MediaPlaybackCommands.PlayPauseToggle);
-                    }
-                    else
-                    {
+                    if (MediaController == null || !MediaController.TryPlayPauseToggle())
                         keybd_event(0xB3 , 0, 1, IntPtr.Zero); // Play pause key
-                    }
                     break;
                 case "current":
                         Services.ChatGui.Print($"[NowPlaying] {CurrentArtist} - {CurrentSong}");
@@ -411,8 +285,18 @@ public sealed class Plugin : IDalamudPlugin
                     }
                     break;
                 case "cycle":
-                        CycleSession();
+                    CycleSession();
                     break;
+                case "mutebgmonplay":
+                    MuteBgmOnPlay = Configuration.MuteBgmOnPlay ^= true;
+                    Configuration.Save();
+                    
+                    if (MuteBgmOnPlay)
+                        Services.ChatGui.Print("[NowPlaying] Enabled muting game BGM when playing media.");
+                    else
+                        Services.ChatGui.Print("[NowPlaying] Disabled muting game BGM when playing media.");
+                    break;
+                    
             }            
         }
     }

--- a/NowPlaying/Plugin.cs
+++ b/NowPlaying/Plugin.cs
@@ -1,12 +1,14 @@
 ﻿using System;
-using System.ComponentModel;
+using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using Dalamud.Game.Command;
 using Dalamud.Game.Config;
 using Dalamud.Plugin;
 using Dalamud.Utility;
 using Dalamud.Game.Gui.Dtr;
+using Dalamud.Interface.ImGuiNotification;
 using NowPlaying.MediaControllers;
+using Notification = Dalamud.Interface.ImGuiNotification.Notification;
 
 namespace NowPlaying;
 
@@ -127,7 +129,41 @@ public sealed class Plugin : IDalamudPlugin
             MediaController = new NpsmMediaController();
 
         MediaController.OnUpdated += OnMediaControllerUpdated;
-        MediaController.Start();
+
+        try
+        {
+            MediaController.Start();
+        }
+        catch (Tmds.DBus.Protocol.DBusConnectionException e)
+        {
+            var notification = new Notification
+            {
+                Type = NotificationType.Error,
+                Title = "Failed to connect to media players",
+                Content = e.InnerException is SocketException { SocketErrorCode: SocketError.AddressFamilyNotSupported }
+                              ? "Cannot connect to media players because Unix sockets are not supported on this version of Wine/Proton. Please try another version of Wine/Proton."
+                              : "An unknown error occured, check logs for details.",
+                Minimized = false,
+                InitialDuration = TimeSpan.MaxValue,
+            };
+
+            Services.NotificationManager.AddNotification(notification);
+            throw;
+        }
+        catch (Exception)
+        {
+            var notification = new Notification
+            {
+                Type = NotificationType.Error,
+                Title = "Failed to connect to media players",
+                Content = "An unknown error occured, check logs for details.",
+                Minimized = false,
+                InitialDuration = TimeSpan.MaxValue,
+            };
+
+            Services.NotificationManager.AddNotification(notification);
+            throw;
+        }
     }
 
     private void OnMediaControllerUpdated(object? sender, EventArgs args)

--- a/NowPlaying/Plugin.cs
+++ b/NowPlaying/Plugin.cs
@@ -122,7 +122,7 @@ public sealed class Plugin : IDalamudPlugin
         dtrDisplay = new ServerInfoDisplay(this);
 
         if (IsWine)
-            MediaController = new PlayerctlMediaController();
+            MediaController = new MprisMediaController();
         else
             MediaController = new NpsmMediaController();
 

--- a/NowPlaying/Services.cs
+++ b/NowPlaying/Services.cs
@@ -16,5 +16,6 @@ public class Services
     [PluginService] internal static IDtrBar DtrBar { get; private set; }
     [PluginService] internal static IFramework Framework { get; private set; }
     [PluginService] internal static IGameConfig GameConfig { get; private set; }
+    [PluginService] internal static INotificationManager NotificationManager { get; private set; }
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 }

--- a/NowPlaying/dbus-xml/org.mpris.MediaPlayer2.Player.xml
+++ b/NowPlaying/dbus-xml/org.mpris.MediaPlayer2.Player.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" ?>
+<node xmlns:tp="http://telepathy.freedesktop.org/wiki/DbusSpec#extensions-v0">
+    <interface name="org.mpris.MediaPlayer2.Player">
+        <method name="Next" tp:name-for-bindings="Next">
+        </method>
+
+        <method name="Previous" tp:name-for-bindings="Previous">
+        </method>
+
+        <method name="Pause" tp:name-for-bindings="Pause">
+        </method>
+
+        <method name="PlayPause" tp:name-for-bindings="PlayPause">
+        </method>
+
+        <method name="Stop" tp:name-for-bindings="Stop">
+        </method>
+
+        <method name="Play" tp:name-for-bindings="Play">
+        </method>
+
+        <method name="Seek" tp:name-for-bindings="Seek">
+            <arg direction="in" type="x" name="Offset" tp:type="Time_In_Us">
+            </arg>
+        </method>
+
+        <method name="SetPosition" tp:name-for-bindings="Set_Position">
+            <arg direction="in" type="o" tp:type="Track_Id" name="TrackId">
+            </arg>
+            <arg direction="in" type="x" tp:type="Time_In_Us" name="Position">
+            </arg>
+        </method>
+
+        <method name="OpenUri" tp:name-for-bindings="Open_Uri">
+            <arg direction="in" type="s" tp:type="Uri" name="Uri">
+            </arg>
+        </method>
+
+        <property name="PlaybackStatus" tp:name-for-bindings="Playback_Status" type="s" tp:type="Playback_Status" access="read">
+            <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
+        </property>
+
+        <property name="LoopStatus" type="s" access="readwrite"
+                  tp:name-for-bindings="Loop_Status" tp:type="Loop_Status">
+            <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
+        </property>
+
+        <property name="Rate" tp:name-for-bindings="Rate" type="d" tp:type="Playback_Rate" access="readwrite">
+            <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
+        </property>
+
+        <property name="Shuffle" tp:name-for-bindings="Shuffle" type="b" access="readwrite">
+            <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
+        </property>
+
+        <property name="Metadata" tp:name-for-bindings="Metadata" type="a{sv}" tp:type="Metadata_Map" access="read">
+            <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
+            <annotation name="org.qtproject.QtDBus.QtTypeName" value="QVariantMap"/>
+        </property>
+
+        <property name="Volume" type="d" tp:type="Volume" tp:name-for-bindings="Volume" access="readwrite">
+            <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true" />
+        </property>
+
+        <property name="Position" type="x" tp:type="Time_In_Us" tp:name-for-bindings="Position" access="read">
+            <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+        </property>
+
+        <property name="MinimumRate" tp:name-for-bindings="Minimum_Rate" type="d" tp:type="Playback_Rate" access="read">
+            <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
+        </property>
+
+        <property name="MaximumRate" tp:name-for-bindings="Maximum_Rate" type="d" tp:type="Playback_Rate" access="read">
+            <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
+        </property>
+
+        <property name="CanGoNext" tp:name-for-bindings="Can_Go_Next" type="b" access="read">
+            <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
+        </property>
+
+        <property name="CanGoPrevious" tp:name-for-bindings="Can_Go_Previous" type="b" access="read">
+            <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
+        </property>
+
+        <property name="CanPlay" tp:name-for-bindings="Can_Play" type="b" access="read">
+            <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
+        </property>
+
+        <property name="CanPause" tp:name-for-bindings="Can_Pause" type="b" access="read">
+            <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
+        </property>
+
+        <property name="CanSeek" tp:name-for-bindings="Can_Seek" type="b" access="read">
+            <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
+        </property>
+
+        <property name="CanControl" tp:name-for-bindings="Can_Control" type="b" access="read">
+            <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+        </property>
+
+        <signal name="Seeked" tp:name-for-bindings="Seeked">
+            <arg name="Position" type="x" tp:type="Time_In_Us">
+            </arg>
+        </signal>
+
+    </interface>
+</node>
+    <!-- vim:set sw=2 sts=2 et ft=xml: -->

--- a/NowPlaying/packages.lock.json
+++ b/NowPlaying/packages.lock.json
@@ -19,6 +19,18 @@
         "requested": "[0.9.14, )",
         "resolved": "0.9.14",
         "contentHash": "E2sS3CayxUEDHP1WH97XrH/ipvg+JQ9SSeUgstF4pTqh2peBh5UH0PAV+44prHqm9pRPwfsab8Sgc8AbKGTCBw=="
+      },
+      "Tmds.DBus.Generator": {
+        "type": "Direct",
+        "requested": "[0.95.0, )",
+        "resolved": "0.95.0",
+        "contentHash": "m95NuLds61L8nXUKg4BOTxVedBrmqDzD+JxIJcDFwIonOI8Jqv0ovUzeK6FKOog4wzLStd35gd1pnGT0d5iLpg=="
+      },
+      "Tmds.DBus.Protocol": {
+        "type": "Direct",
+        "requested": "[0.95.0, )",
+        "resolved": "0.95.0",
+        "contentHash": "qsC7o0FVMB/j+3Zt0ppoORlpWticKsHMN5NFG6egiUz3yYspqiV/3TxSK9iuitg1w6IYbMcwelPkLgeE8T074w=="
       }
     }
   }


### PR DESCRIPTION
This adds Linux support to the plugin by directly interfacing with the MPRIS D-Bus interface, without going through the WinRT SMTC API.
- The existing implementation using SMTC has been extracted into its own class behind an abstract interface. The plugin switches between implementations at runtime based on the `IsWine` flag.
- All current plugin commands are supported by the D-Bus implementation.

This only works on Wine/Proton builds with AF_UNIX socket support. This includes the official wine-xiv build and GE-Proton 11.

Also added a feature to mute game BGM while music is playing.

<img width="495" height="197" alt="image" src="https://github.com/user-attachments/assets/ae11232d-e950-4a25-ad83-eeeb380c656f" />
